### PR TITLE
Feat/command pack

### DIFF
--- a/fang-mcb-project/src/control/command/command_pack.cpp
+++ b/fang-mcb-project/src/control/command/command_pack.cpp
@@ -1,0 +1,15 @@
+#include "command_pack.hpp"
+
+namespace fang::command
+{
+    CommandPack::CommandPack(CommandMapper& mapper) : mapper_{mapper}
+    {
+    }
+    void CommandPack::registerCommands(std::span<CommandMapping> mappings)
+    {
+        for(auto& mapping : mappings) 
+        {
+            mapper_.addMap(&mapping);
+        }
+    }
+}

--- a/fang-mcb-project/src/control/command/command_pack.cpp
+++ b/fang-mcb-project/src/control/command/command_pack.cpp
@@ -5,6 +5,7 @@ namespace fang::command
     CommandPack::CommandPack(CommandMapper& mapper) : mapper_{mapper}
     {
     }
+
     void CommandPack::registerCommandMappings(std::span<CommandMapping> mappings)
     {
         for(auto& mapping : mappings) 

--- a/fang-mcb-project/src/control/command/command_pack.cpp
+++ b/fang-mcb-project/src/control/command/command_pack.cpp
@@ -6,11 +6,11 @@ namespace fang::command
     {
     }
 
-    void CommandPack::registerCommandMappings(std::span<CommandMapping> mappings)
+    void CommandPack::registerCommandMappings(std::span<std::reference_wrapper<CommandMapping>> mappings)
     {
-        for(auto& mapping : mappings) 
+        for(auto mapping : mappings) 
         {
-            mapper_.addMap(&mapping);
+            mapper_.addMap(&mapping.get());
         }
     }
 }

--- a/fang-mcb-project/src/control/command/command_pack.cpp
+++ b/fang-mcb-project/src/control/command/command_pack.cpp
@@ -5,7 +5,7 @@ namespace fang::command
     CommandPack::CommandPack(CommandMapper& mapper) : mapper_{mapper}
     {
     }
-    void CommandPack::registerCommands(std::span<CommandMapping> mappings)
+    void CommandPack::registerCommandMappings(std::span<CommandMapping> mappings)
     {
         for(auto& mapping : mappings) 
         {

--- a/fang-mcb-project/src/control/command/command_pack.hpp
+++ b/fang-mcb-project/src/control/command/command_pack.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "tap/control/command_mapper.hpp"
+#include "tap/control/command_mapping.hpp"
+
+#include <span>
+
+namespace fang::command
+{
+    /**
+     * This is a family of classes which wire commands and subsystems together.
+     * 
+     * Mappers will often accept references to subsystems and then pass them into
+     * the constructors of commands and whatnot.
+     * 
+     * They will also connect mappers as well.
+     */
+    class CommandPack
+    {
+    public:
+        using CommandMapper = tap::control::CommandMapper;
+        using CommandMapping = tap::control::CommandMapping;
+
+        virtual void initialize() = 0;
+
+        CommandPack(CommandMapper& mapper);
+    protected:
+        void registerCommands(std::span<CommandMapping> mappings);
+    private:
+        tap::control::CommandMapper& mapper_;
+    };
+}

--- a/fang-mcb-project/src/control/command/command_pack.hpp
+++ b/fang-mcb-project/src/control/command/command_pack.hpp
@@ -4,6 +4,7 @@
 #include "tap/control/command_mapping.hpp"
 
 #include <span>
+#include <functional>
 
 namespace fang::command
 {
@@ -28,7 +29,7 @@ namespace fang::command
 
         virtual ~CommandPack() = default; 
     protected:
-        void registerCommandMappings(std::span<CommandMapping> mappings);
+        void registerCommandMappings(std::span<std::reference_wrapper<CommandMapping>> mappings);
     private:
         tap::control::CommandMapper& mapper_;
     };

--- a/fang-mcb-project/src/control/command/command_pack.hpp
+++ b/fang-mcb-project/src/control/command/command_pack.hpp
@@ -25,6 +25,8 @@ namespace fang::command
         virtual void initialize() = 0;
 
         CommandPack(CommandMapper& mapper);
+
+        virtual ~CommandPack() = default; 
     protected:
         void registerCommandMappings(std::span<CommandMapping> mappings);
     private:

--- a/fang-mcb-project/src/control/command/command_pack.hpp
+++ b/fang-mcb-project/src/control/command/command_pack.hpp
@@ -20,12 +20,13 @@ namespace fang::command
     public:
         using CommandMapper = tap::control::CommandMapper;
         using CommandMapping = tap::control::CommandMapping;
+        using RemoteState = tap::control::RemoteMapState;
 
         virtual void initialize() = 0;
 
         CommandPack(CommandMapper& mapper);
     protected:
-        void registerCommands(std::span<CommandMapping> mappings);
+        void registerCommandMappings(std::span<CommandMapping> mappings);
     private:
         tap::control::CommandMapper& mapper_;
     };

--- a/fang-mcb-project/src/control/command/pierce_command_pack.cpp
+++ b/fang-mcb-project/src/control/command/pierce_command_pack.cpp
@@ -27,6 +27,12 @@ namespace fang::command
             turretInput_{drivers.remote, config.inputConfig.turretInputConfig}
         {}
 
+    void PierceCommandPack::initialize()
+    {
+        setDefaultCommands();
+        registerIoMappings();
+    }
+
     void PierceCommandPack::setDefaultCommands()
     {
         gimbal_.setDefaultCommand(&aim_);

--- a/fang-mcb-project/src/control/command/pierce_command_pack.cpp
+++ b/fang-mcb-project/src/control/command/pierce_command_pack.cpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "pierce_command_pack.hpp"
+
+namespace fang::command
+{
+        PierceCommandPack::PierceCommandPack
+        (
+            Drivers& drivers, 
+            turret::SimpleAmmoBoosterSubsystem& booster,
+            turret::SimpleFeederSubsystem& feeder,
+            turret::FieldGimbalSubsystem& gimbal,
+            chassis::HolonomicSubsystem& chassis,
+            const Config& config
+        ):
+            CommandPack{drivers.commandMapper},
+
+            kCommandConfig_{config.commandConfig},
+            kRemoteMapping_{config.mappingConfig.remote},
+            kComputerMapping_{config.mappingConfig.computer},
+            drivers_{drivers},
+            booster_{booster},
+            feeder_{feeder},
+            gimbal_{gimbal},
+            chassis_{chassis},
+            chassisInput_{drivers.remote, config.inputConfig.chassisInputConfig},
+            turretInput_{drivers.remote, config.inputConfig.turretInputConfig}
+        {}
+
+    void PierceCommandPack::setDefaultCommands()
+    {
+        gimbal_.setDefaultCommand(&aim_);
+    }
+
+    void PierceCommandPack::registerIoMappings()
+    {
+        drivers_.commandMapper.addMap(&activateBoosterRemote_);
+        drivers_.commandMapper.addMap(&activateAutofireRemote_);
+        drivers_.commandMapper.addMap(&activateAutofireMouseMap_);
+        drivers_.commandMapper.addMap(&unjamMouse_);
+        drivers_.commandMapper.addMap(&unjamRemote_);
+
+        drivers_.commandMapper.addMap(&counterStrikeRemote_);
+        drivers_.commandMapper.addMap(&shurikenRemote_);
+        drivers_.commandMapper.addMap(&tardisRemote_);
+
+        drivers_.commandMapper.addMap(&counterStrikeKeyboard_);
+        drivers_.commandMapper.addMap(&shruikenKeyboard_);
+        drivers_.commandMapper.addMap(&tardisRemote_);
+    }
+}

--- a/fang-mcb-project/src/control/command/pierce_command_pack.hpp
+++ b/fang-mcb-project/src/control/command/pierce_command_pack.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include "command_pack.hpp"
+
+// Input
+#include "control/turret/turret_input_handler.hpp"
+#include "control/chassis/chassis_input_handler.hpp"
+
+// Chassis Commands
+#include "control/chassis/drive/holonomic/command/counter_strike_command.hpp"
+#include "control/chassis/drive/holonomic/command/shuriken_command.hpp"
+#include "control/chassis/drive/holonomic/command/tardis_command.hpp"
+
+// Turret Commands
+#include "control/turret/gimbal/command/aim_command.hpp"
+#include "control/turret/ammo_booster/command/activate_booster_command.hpp"
+#include "control/turret/feeder/command/simple_autofire_command.hpp"
+#include "control/turret/feeder/command/simple_unjam_command.hpp"
+
+// Mapping Types
+#include "tap/control/press_command_mapping.hpp"
+#include "tap/control/hold_command_mapping.hpp"
+
+#include "tap/control/remote_map_state.hpp"
+
+namespace fang::command
+{
+    class PierceCommandPack : public CommandPack
+    {
+
+        struct InputConfig
+        {
+            chassis::ChassisInputHandler::Config chassisInputConfig;
+            turret::TurretInputHandler::Config turretInputConfig;
+        };
+
+        struct CommandConfig
+        {
+            turret::AimCommand::Config aimConfig;
+            chassis::CounterStrikeCommand::Config counterStrikeConfig;
+            chassis::ShurikenCommand::Config shurikenConfig;
+            chassis::TardisCommand::Config tardisConfig;
+        };
+
+        struct RemoteMapping
+        {
+            RemoteState activateBooster;
+            RemoteState fire;
+            RemoteState unjam;
+            RemoteState counterStrike;
+            RemoteState shuriken;
+            RemoteState tardis;
+        };
+
+        struct ComputerMapping
+        {
+            RemoteState mouseFire;
+            RemoteState mouseUnjam;
+            RemoteState counterStrike;
+            RemoteState shuriken;
+            RemoteState tardis;
+        };
+
+        struct MappingConfig
+        {
+            RemoteMapping remote;
+            ComputerMapping computer;
+        };
+
+        struct Config
+        {
+            InputConfig inputConfig;
+            MappingConfig mappingConfig;
+            CommandConfig commandConfig;
+        };
+
+        PierceCommandPack
+        (
+            Drivers& drivers, 
+            turret::SimpleAmmoBoosterSubsystem& booster,
+            turret::SimpleFeederSubsystem& feeder,
+            turret::FieldGimbalSubsystem& gimbal,
+            chassis::HolonomicSubsystem& chassis,
+            const Config& config
+        );
+    private:
+        void registerIoMappings();
+        void setDefaultCommands();
+
+        turret::SimpleAmmoBoosterSubsystem& booster_;
+        turret::SimpleFeederSubsystem& feeder_;
+        turret::FieldGimbalSubsystem& gimbal_;
+        chassis::HolonomicSubsystem& chassis_;
+
+        Drivers& drivers_;
+        //Used only for initialization DO NOT ACCESS AFTERWARDS
+        const CommandConfig& kCommandConfig_;
+        const RemoteMapping& kRemoteMapping_;
+        const ComputerMapping& kComputerMapping_;
+
+        chassis::ChassisInputHandler chassisInput_;
+        turret::TurretInputHandler turretInput_;
+
+        turret::AimCommand aim_{gimbal_, turretInput_, kCommandConfig_.aimConfig};
+        turret::ActivateBoosterCommand activateBooster_{booster_};
+        fang::turret::AutofireCommand autofire_{feeder_};
+        fang::turret::UnjamCommand unjam_{feeder_};
+
+        tap::control::HoldCommandMapping activateBoosterRemote_{&drivers_, {&activateBooster_}, kRemoteMapping_.activateBooster};
+        tap::control::HoldCommandMapping activateAutofireRemote_{&drivers_, {&autofire_}, kRemoteMapping_.fire};
+
+        tap::control::HoldCommandMapping activateAutofireMouseMap_{&drivers_, {&autofire_}, kComputerMapping.mouseFire};
+        tap::control::HoldCommandMapping unjamMouse_{&drivers_, {&unjam_}, kComputerMapping_.mouseUnjam};
+        tap::control::HoldCommandMapping unjamRemote_{&drivers_, {&unjam_}, kRemoteMapping.remoteUnjam};
+
+        chassis::CounterStrikeCommand counterStrike_{chassis_, gimbal_, chassisInput_, kCommandConfig_.counterStrikeConfig};
+        chassis::ShurikenCommand shuriken_{chassis_, gimbal_, chassisInput_, kCommandConfig_.shurikenConfig};
+        chassis::TardisCommand tardis_{chassis_, gimbal_, chassisInput_, kCommandConfig_.tardisConfig};
+
+        tap::control::HoldCommandMapping counterStrikeRemote_{&drivers_, {&counterStrike_}, kRemoteMapping.fieldMecanumMode};
+        tap::control::PressCommandMapping shurikenRemote_{&drivers_, {&shuriken_}, kRemoteMapping_.shuriken};
+        tap::control::PressCommandMapping tardisRemote_{&drivers_, {&tardis_}, kRemoteMapping_.tardis};
+
+        tap::control::PressCommandMapping counterStrikeKeyboard_{&drivers_, {&counterStrike_}, kComputerMapping_.counterStrike};
+        tap::control::PressCommandMapping shruikenKeyboard_{&drivers_, {&shuriken_}, kComputerMapping_.shuriken};
+        tap::control::PressCommandMapping tardisKeyboard_{&drivers_, {&tardis_}, kComputerMapping_.tardis};
+    };
+}

--- a/fang-mcb-project/src/control/command/pierce_command_pack.hpp
+++ b/fang-mcb-project/src/control/command/pierce_command_pack.hpp
@@ -27,7 +27,7 @@ namespace fang::command
 {
     class PierceCommandPack : public CommandPack
     {
-
+    public:
         struct InputConfig
         {
             chassis::ChassisInputHandler::Config chassisInputConfig;
@@ -83,6 +83,8 @@ namespace fang::command
             chassis::HolonomicSubsystem& chassis,
             const Config& config
         );
+
+        virtual void initialize() override;
     private:
         void registerIoMappings();
         void setDefaultCommands();

--- a/fang-mcb-project/src/control/command/pierce_command_pack.hpp
+++ b/fang-mcb-project/src/control/command/pierce_command_pack.hpp
@@ -111,15 +111,15 @@ namespace fang::command
         tap::control::HoldCommandMapping activateBoosterRemote_{&drivers_, {&activateBooster_}, kRemoteMapping_.activateBooster};
         tap::control::HoldCommandMapping activateAutofireRemote_{&drivers_, {&autofire_}, kRemoteMapping_.fire};
 
-        tap::control::HoldCommandMapping activateAutofireMouseMap_{&drivers_, {&autofire_}, kComputerMapping.mouseFire};
+        tap::control::HoldCommandMapping activateAutofireMouseMap_{&drivers_, {&autofire_}, kComputerMapping_.mouseFire};
         tap::control::HoldCommandMapping unjamMouse_{&drivers_, {&unjam_}, kComputerMapping_.mouseUnjam};
-        tap::control::HoldCommandMapping unjamRemote_{&drivers_, {&unjam_}, kRemoteMapping.remoteUnjam};
+        tap::control::HoldCommandMapping unjamRemote_{&drivers_, {&unjam_}, kRemoteMapping_.unjam};
 
         chassis::CounterStrikeCommand counterStrike_{chassis_, gimbal_, chassisInput_, kCommandConfig_.counterStrikeConfig};
         chassis::ShurikenCommand shuriken_{chassis_, gimbal_, chassisInput_, kCommandConfig_.shurikenConfig};
         chassis::TardisCommand tardis_{chassis_, gimbal_, chassisInput_, kCommandConfig_.tardisConfig};
 
-        tap::control::HoldCommandMapping counterStrikeRemote_{&drivers_, {&counterStrike_}, kRemoteMapping.fieldMecanumMode};
+        tap::control::HoldCommandMapping counterStrikeRemote_{&drivers_, {&counterStrike_}, kRemoteMapping_.counterStrike};
         tap::control::PressCommandMapping shurikenRemote_{&drivers_, {&shuriken_}, kRemoteMapping_.shuriken};
         tap::control::PressCommandMapping tardisRemote_{&drivers_, {&tardis_}, kRemoteMapping_.tardis};
 

--- a/fang-mcb-project/src/robot/variant/pierce/config/command/field_mecanum_config.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/command/field_mecanum_config.hpp
@@ -4,7 +4,7 @@
 
 namespace fang::robot
 {
-    static const chassis::CounterStrikeCommand::Config k_fieldMecanumConfig 
+    static const chassis::CounterStrikeCommand::Config kFieldMecanumConfig 
     {
         .maxTranslation = {12_mph, 12_mph},
         .maxRotation    = 300_rpm,

--- a/fang-mcb-project/src/robot/variant/pierce/config/command/shuriken_config.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/command/shuriken_config.hpp
@@ -3,7 +3,7 @@
 #include "control/chassis/drive/holonomic/command/shuriken_command.hpp"
 namespace fang::robot
 {
-    static const chassis::ShurikenCommand::Config k_shurikenConfig
+    static const chassis::ShurikenCommand::Config kShurikenConfig
     {
         .maxTranslation = {6.5_mph, 6.5_mph},
         .shurikenSpeed          = 300_rpm,

--- a/fang-mcb-project/src/robot/variant/pierce/config/command/turret_aim_config.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/command/turret_aim_config.hpp
@@ -6,7 +6,7 @@
 namespace fang::robot
 {
     using namespace units::literals;
-    static const turret::AimCommand::Config k_turretAimConfig
+    static const turret::AimCommand::Config kTurretAimConfig
     {
         .maxPitchSpeed = 40_rpm,
         .maxYawSpeed = 120_rpm,

--- a/fang-mcb-project/src/robot/variant/pierce/config/input/chassis_input_config.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/input/chassis_input_config.hpp
@@ -23,7 +23,7 @@ namespace fang::robot
         Key::D  //right
     };
 
-    static const chassis::ChassisInputHandler::Config k_chassisInputConfig
+    static const chassis::ChassisInputHandler::Config kChassisInputConfig
     {
         k_chassisInputRemoteConfig,
         k_chassisInputKeyboardConfig

--- a/fang-mcb-project/src/robot/variant/pierce/config/input/turret_input_config.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/input/turret_input_config.hpp
@@ -18,7 +18,7 @@ namespace fang::robot
         .pitchPercentagePerPx   = 0.15,
         .yawPercentagePerPx     = 0.15
     };
-    static const turret::TurretInputHandler::Config k_turretInputConfig
+    static const turret::TurretInputHandler::Config kTurretInputConfig
     {
         k_turretInputRemoteConfig,
         k_turretInputMouseConfig

--- a/fang-mcb-project/src/robot/variant/pierce/config/mapping/chassis_command_map.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/mapping/chassis_command_map.hpp
@@ -13,35 +13,35 @@ namespace fang::robot
     static const SwitchState k_fieldShurikenLeftSwitchActivate{SwitchState::UP};
     static const SwitchState k_tardisLeftSwitchActivate{SwitchState::DOWN};
 
-    static const tap::control::RemoteMapState k_fieldMecanumRemoteState
+    static const tap::control::RemoteMapState kFieldMecanumRemoteState
     {
         k_chassisRightSwitchContext,
         k_fieldMecanumLeftSwitchActivate
     };
 
-    static const tap::control::RemoteMapState k_shurikenModeRemoteState
+    static const tap::control::RemoteMapState kShurikenModeRemoteState
     {
         k_chassisRightSwitchContext,
         k_fieldShurikenLeftSwitchActivate
     };
 
-    static const tap::control::RemoteMapState k_tardisModeRemoteState
+    static const tap::control::RemoteMapState kTardisModeRemoteState
     {
         k_chassisRightSwitchContext,
         k_tardisLeftSwitchActivate
     };
 
-    static const tap::control::RemoteMapState k_fieldMecanumKeyboardState
+    static const tap::control::RemoteMapState kFieldMecanumKeyboardState
     {
         {Key::E}
     };
 
-    static const tap::control::RemoteMapState k_shurikenModeKeyboardState
+    static const tap::control::RemoteMapState kShurikenModeKeyboardState
     {
         {Key::Q}
     };
 
-    static const tap::control::RemoteMapState k_tardisModeKeyboardState
+    static const tap::control::RemoteMapState kTardisModeKeyboardState
     {
         {Key::R}
     };

--- a/fang-mcb-project/src/robot/variant/pierce/config/mapping/turret_command_map.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/config/mapping/turret_command_map.hpp
@@ -6,30 +6,30 @@ namespace fang::robot
     using Remote = tap::communication::serial::Remote;
     using Key = Remote::Key;
     using MouseButton = tap::control::RemoteMapState::MouseButton;
-    static const tap::control::RemoteMapState k_activateBoosterRemoteState
+    static const tap::control::RemoteMapState kActivateBoosterRemoteState
     {
         Remote::Switch::LEFT_SWITCH,
         Remote::SwitchState::UP
     };
 
-    static const tap::control::RemoteMapState k_autofireRemoteState
+    static const tap::control::RemoteMapState kAutofireRemoteState
     {
         Remote::SwitchState::UP,
         Remote::SwitchState::UP
     };
 
-    static const tap::control::RemoteMapState k_unjamRemoteState
+    static const tap::control::RemoteMapState kUnjamRemoteState
     {
         Remote::SwitchState::UP,
         Remote::SwitchState::DOWN
     };
 
-    static const tap::control::RemoteMapState k_autofireMouseState
+    static const tap::control::RemoteMapState kAutofireMouseState
     {
         MouseButton::LEFT
     };
 
-    static const tap::control::RemoteMapState k_unjamMouseState
+    static const tap::control::RemoteMapState kUnjamMouseState
     {
         MouseButton::RIGHT
     };

--- a/fang-mcb-project/src/robot/variant/pierce/pierce.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/pierce.hpp
@@ -49,6 +49,6 @@ namespace fang::robot
 
         command::PierceCommandPack commandPack_;
 
-    };//class Robot
-}//namspace control
+    };
+}
 #endif

--- a/fang-mcb-project/src/robot/variant/pierce/pierce.hpp
+++ b/fang-mcb-project/src/robot/variant/pierce/pierce.hpp
@@ -8,24 +8,7 @@
 #include "control/turret/feeder/simple_feeder/m2006_simple_feeder.hpp"
 #include "custom_variant/subsystem/pierce_ammo_booster.hpp"
 
-//Input handlers
-#include "control/turret/turret_input_handler.hpp"
-#include "control/chassis/chassis_input_handler.hpp"
-
-//Commands
-#include "control/chassis/drive/holonomic/command/counter_strike_command.hpp"
-#include "control/chassis/drive/holonomic/command/shuriken_command.hpp"
-#include "control/chassis/drive/holonomic/command/tardis_command.hpp"
-
-#include "control/turret/gimbal/command/aim_command.hpp"
-#include "control/turret/ammo_booster/command/activate_booster_command.hpp"
-#include "control/turret/feeder/command/simple_autofire_command.hpp"
-#include "control/turret/feeder/command/simple_unjam_command.hpp"
-
-#include "wrap/trap/communication/sensors/imu.hpp"
-
-#include "tap/control/press_command_mapping.hpp"
-#include "tap/control/hold_command_mapping.hpp"
+#include "control/command/pierce_command_pack.hpp"
 
 namespace fang::robot
 {
@@ -45,41 +28,10 @@ namespace fang::robot
             turret::PierceAmmoBooster::Config boosterConfig;
         };
 
-        struct InputConfig
-        {
-            chassis::ChassisInputHandler::Config chassisInputConfig;
-            turret::TurretInputHandler::Config turretInputConfig;
-        };
-
-        struct CommandConfig
-        {
-            turret::AimCommand::Config aimCommandConfig;
-            chassis::CounterStrikeCommand::Config fieldMecanumConfig;
-            chassis::ShurikenCommand::Config shurikenConfig;
-            chassis::TardisCommand::Config tardisConfig;
-        };
-
-        struct MappingConfig
-        {
-            RemoteState remoteActivateBooster;
-            RemoteState remoteFire;
-            RemoteState remoteUnjam;
-            RemoteState remoteFieldMecanumMode;
-            RemoteState remoteShurikenMode;
-            RemoteState remoteTardisMode;
-            RemoteState mouseFire;
-            RemoteState mouseUnjam;
-            RemoteState keyboardFieldMecanumMode;
-            RemoteState keyboardShurikenMode;
-            RemoteState keyboardTardisMode;
-        };
-
         struct Config
         {
             SubsystemConfig subsystemConfig;
-            InputConfig inputConfig;
-            MappingConfig mappingConfig;
-            CommandConfig commandConfig;
+            command::PierceCommandPack::Config commandPackConfig;
         };
 
         Pierce(Drivers& drivers, const Config& config);
@@ -88,55 +40,15 @@ namespace fang::robot
         static constexpr Milliseconds k_startupDelay{1500};
 
         void initializeSubsystems();
-        void setDefaultCommands();
-        void registerIoMappings();
-
-        Drivers& m_drivers;
-
-        const SubsystemConfig mk_subsystemConfig;
-        const InputConfig mk_inputConfig;
-        const MappingConfig kMappingConfig_;
-        const CommandConfig mk_commandConfig;
-
-
-        trap::communication::sensors::Imu m_imu;
+        void initializeCommands();
 
         std::unique_ptr<turret::PierceFieldGimbal> gimbal_;
         std::unique_ptr<fang::turret::SimpleFeeder> feeder_;
         std::unique_ptr<fang::turret::PierceAmmoBooster> booster_;
         std::unique_ptr<fang::chassis::PierceMecanumDrive> mecanumDrive_;
-        //Compatibility hacks
-        turret::PierceFieldGimbal& m_gimbal{*gimbal_};
-        turret::SimpleFeeder& m_feeder{*feeder_};
-        turret::PierceAmmoBooster& m_booster{*booster_};
-        chassis::PierceMecanumDrive& m_chassis{*mecanumDrive_};
 
-        chassis::ChassisInputHandler m_chassisInput;
-        turret::TurretInputHandler m_turretInput;
+        command::PierceCommandPack commandPack_;
 
-        turret::AimCommand m_aimCommnd{m_gimbal, m_turretInput, mk_commandConfig.aimCommandConfig};
-        turret::ActivateBoosterCommand m_activateBoosterCommand{m_booster};
-        fang::turret::AutofireCommand m_autofireCommand{m_feeder};
-        fang::turret::UnjamCommand m_unjamCommand{m_feeder};
-
-        tap::control::HoldCommandMapping m_activateBoosterRemoteMap{&m_drivers, {&m_activateBoosterCommand}, kMappingConfig_.remoteActivateBooster};
-        tap::control::HoldCommandMapping m_activateAutofireRemoteMap{&m_drivers, {&m_autofireCommand}, kMappingConfig_.remoteFire};
-
-        tap::control::HoldCommandMapping m_activateAutofireMouseMap{&m_drivers, {&m_autofireCommand}, kMappingConfig_.mouseFire};
-        tap::control::HoldCommandMapping m_unjamCommandMap{&m_drivers, {&m_unjamCommand}, kMappingConfig_.mouseUnjam};
-        tap::control::HoldCommandMapping m_unjamCommandMapRemote{&m_drivers, {&m_unjamCommand}, kMappingConfig_.remoteUnjam};
-
-        chassis::CounterStrikeCommand m_fieldMecanumCommand{m_chassis, m_gimbal, m_chassisInput, mk_commandConfig.fieldMecanumConfig};
-        chassis::ShurikenCommand m_shurikenCommand{m_chassis, m_gimbal, m_chassisInput, mk_commandConfig.shurikenConfig};
-        chassis::TardisCommand m_tardisCommand{m_chassis, m_gimbal, m_chassisInput, mk_commandConfig.tardisConfig};
-
-        tap::control::HoldCommandMapping m_fieldMecanumRemoteMap{&m_drivers, {&m_fieldMecanumCommand}, kMappingConfig_.remoteFieldMecanumMode};
-        tap::control::PressCommandMapping m_shurikenRemoteMap{&m_drivers, {&m_shurikenCommand}, kMappingConfig_.remoteShurikenMode};
-        tap::control::PressCommandMapping m_tardisRemoteMap{&m_drivers, {&m_tardisCommand}, kMappingConfig_.remoteTardisMode};
-
-        tap::control::PressCommandMapping m_fieldMecanumKeyboardMap{&m_drivers, {&m_fieldMecanumCommand}, kMappingConfig_.keyboardFieldMecanumMode};
-        tap::control::PressCommandMapping m_shurikenKeyboardMap{&m_drivers, {&m_shurikenCommand}, kMappingConfig_.keyboardShurikenMode};
-        tap::control::PressCommandMapping m_tardisKeyboardMap{&m_drivers, {&m_tardisCommand}, kMappingConfig_.keyboardTardisMode};
     };//class Robot
 }//namspace control
 #endif

--- a/fang-mcb-project/src/robot/variant/pierce/pierce_config.cpp
+++ b/fang-mcb-project/src/robot/variant/pierce/pierce_config.cpp
@@ -33,35 +33,35 @@ namespace fang::robot
 
     const command::PierceCommandPack::InputConfig kPierceInputConfig 
     {
-        .chassisInputConfig = k_chassisInputConfig,
-        .turretInputConfig  = k_turretInputConfig
+        .chassisInputConfig = kChassisInputConfig,
+        .turretInputConfig  = kTurretInputConfig
     };
 
     const command::PierceCommandPack::CommandConfig k_pierceCommandConfig
     {
-        .aimConfig           = k_turretAimConfig,
-        .counterStrikeConfig = k_fieldMecanumConfig,
-        .shurikenConfig      = k_shurikenConfig,
+        .aimConfig           = kTurretAimConfig,
+        .counterStrikeConfig = kFieldMecanumConfig,
+        .shurikenConfig      = kShurikenConfig,
         .tardisConfig        = k_tardisConfig
     };
 
     const command::PierceCommandPack::ComputerMapping kPierceComputerMappingCOnfig 
     {
-        .mouseFire     = k_autofireMouseState,
-        .mouseUnjam    = k_unjamMouseState,
-        .counterStrike = k_fieldMecanumKeyboardState,
-        .shuriken      = k_shurikenModeKeyboardState,
-        .tardis        = k_tardisModeKeyboardState
+        .mouseFire     = kAutofireMouseState,
+        .mouseUnjam    = kUnjamMouseState,
+        .counterStrike = kFieldMecanumKeyboardState,
+        .shuriken      = kShurikenModeKeyboardState,
+        .tardis        = kTardisModeKeyboardState
     };
 
     const command::PierceCommandPack::RemoteMapping kPierceRemoteMappingConfig 
     {
-        .activateBooster = k_activateBoosterRemoteState,
-        .fire            = k_autofireRemoteState,
-        .unjam           = k_unjamRemoteState,
-        .counterStrike   = k_fieldMecanumRemoteState,
-        .shuriken        = k_shurikenModeRemoteState,
-        .tardis          = k_tardisModeRemoteState
+        .activateBooster = kActivateBoosterRemoteState,
+        .fire            = kAutofireRemoteState,
+        .unjam           = kUnjamRemoteState,
+        .counterStrike   = kFieldMecanumRemoteState,
+        .shuriken        = kShurikenModeRemoteState,
+        .tardis          = kTardisModeRemoteState
     };
 
     const command::PierceCommandPack::MappingConfig kPierceMappingConfig 

--- a/fang-mcb-project/src/robot/variant/pierce/pierce_config.cpp
+++ b/fang-mcb-project/src/robot/variant/pierce/pierce_config.cpp
@@ -23,7 +23,7 @@
 
 namespace fang::robot
 {
-    const Pierce::SubsystemConfig k_pierceSubsytemConfig 
+    const Pierce::SubsystemConfig kPierceSubsystemConfig 
     {
         .chassisConfig  = kChassisConfig,
         .gimbalConfig   = kGimbalSubsystemConfig,
@@ -31,40 +31,55 @@ namespace fang::robot
         .boosterConfig  = kAmmoBoosterConfig
     };
 
-    const Pierce::InputConfig k_pierceInputConfig
+    const command::PierceCommandPack::InputConfig kPierceInputConfig 
     {
         .chassisInputConfig = k_chassisInputConfig,
         .turretInputConfig  = k_turretInputConfig
     };
 
-    const Pierce::CommandConfig k_pierceCommandConfig
+    const command::PierceCommandPack::CommandConfig k_pierceCommandConfig
     {
-        .aimCommandConfig   = k_turretAimConfig,
-        .fieldMecanumConfig = k_fieldMecanumConfig,
-        .shurikenConfig     = k_shurikenConfig,
-        .tardisConfig       = k_tardisConfig
+        .aimConfig           = k_turretAimConfig,
+        .counterStrikeConfig = k_fieldMecanumConfig,
+        .shurikenConfig      = k_shurikenConfig,
+        .tardisConfig        = k_tardisConfig
     };
 
-    const Pierce::MappingConfig k_pierceMappingConfig
+    const command::PierceCommandPack::ComputerMapping kPierceComputerMappingCOnfig 
     {
-        .remoteActivateBooster      = k_activateBoosterRemoteState,
-        .remoteFire                 = k_autofireRemoteState,
-        .remoteUnjam                = k_unjamRemoteState,
-        .remoteFieldMecanumMode     = k_fieldMecanumRemoteState,
-        .remoteShurikenMode         = k_shurikenModeRemoteState,
-        .remoteTardisMode           = k_tardisModeRemoteState,
-        .mouseFire                  = k_autofireMouseState,
-        .mouseUnjam                 = k_unjamMouseState,
-        .keyboardFieldMecanumMode   = k_fieldMecanumKeyboardState,
-        .keyboardShurikenMode       = k_shurikenModeKeyboardState,
-        .keyboardTardisMode         = k_tardisModeKeyboardState
+        .mouseFire     = k_autofireMouseState,
+        .mouseUnjam    = k_unjamMouseState,
+        .counterStrike = k_fieldMecanumKeyboardState,
+        .shuriken      = k_shurikenModeKeyboardState,
+        .tardis        = k_tardisModeKeyboardState
+    };
+
+    const command::PierceCommandPack::RemoteMapping kPierceRemoteMappingConfig 
+    {
+        .activateBooster = k_activateBoosterRemoteState,
+        .fire            = k_autofireRemoteState,
+        .unjam           = k_unjamRemoteState,
+        .counterStrike   = k_fieldMecanumRemoteState,
+        .shuriken        = k_shurikenModeRemoteState,
+        .tardis          = k_tardisModeRemoteState
+    };
+
+    const command::PierceCommandPack::MappingConfig kPierceMappingConfig 
+    {
+        .remote     = kPierceRemoteMappingConfig,
+        .computer   = kPierceComputerMappingCOnfig
+    };
+
+    const command::PierceCommandPack::Config kPierceCommandPackConfig
+    {
+        .inputConfig   = kPierceInputConfig,
+        .mappingConfig = kPierceMappingConfig,
+        .commandConfig = k_pierceCommandConfig
     };
 
     const Pierce::Config k_pierceConfig
     {
-        .subsystemConfig    = k_pierceSubsytemConfig,
-        .inputConfig        = k_pierceInputConfig,
-        .mappingConfig      = k_pierceMappingConfig,
-        .commandConfig      = k_pierceCommandConfig
+        .subsystemConfig   = kPierceSubsystemConfig,
+        .commandPackConfig = kPierceCommandPackConfig
     };
 }


### PR DESCRIPTION
The lack of motion error has been traced to initialization values not being passed down. Oh it's because the configs are being stored in a reference. Fix in a separate commit.